### PR TITLE
Heading anchor truncated

### DIFF
--- a/docs/test-md-library/test.md
+++ b/docs/test-md-library/test.md
@@ -3,15 +3,26 @@ title: Testing markdown-it and extensions
 ---
 # Common Mark Test file
 
-## TOC
+## TOC and Header HTML id attribute
 
-Requires markdown-it extension `markdown-it-anchor` and `markdown-it-table-of-contents`
+Requires markdown-it extensions `markdown-it-anchor` and `markdown-it-toc-done-right`.
 
 ```markdown
 [[toc]]
 ```
 
 [[toc]]
+
+Note that the extension `markdown-it-anchor` adds an [HTML id Attribute](https://www.w3schools.com/html/html_id.asp) to each header based on the header title truncated to the first colon (`:`).  Thanks to this id it is possible to create links to any header as follows:
+
+```markdown
+### TASK01: Update this readme
+
+This is a [link to TASK 01](#task01)
+```
+### TASK01: update this readme
+
+This is a [link to TASK01](#task01)
 
 ## Symbols
 

--- a/nodes/lib/serveMarkdown.js
+++ b/nodes/lib/serveMarkdown.js
@@ -85,7 +85,7 @@ module.exports = function serveMarkdown(RED, node){
     //     [link to RULE_001](#rule_001)
     // see also https://www.npmjs.com/package/markdown-it-anchor#user-friendly-urls
     // const truncatedSlugify = s => ((string(s).splitLeft(':',1))[Ø]).slugify().toString()
-    const anchorOptions = {
+    const truncatedSlugifyOption = {
          slugify : (s) => encodeURIComponent(String(s).split(':')[0].trim().toLowerCase().replace(/\s+/g, '-'))
     }
 
@@ -104,8 +104,8 @@ module.exports = function serveMarkdown(RED, node){
         .use(require('markdown-it-emoji'))
         .use(require('@gerhobbelt/markdown-it-include'),includeOptions)
         .use(require('markdown-it-playground'))
-        .use(require('markdown-it-anchor'),anchorOptions)
-        .use(require('markdown-it-table-of-contents'))
+        .use(require('markdown-it-anchor'),        truncatedSlugifyOption)
+        .use(require('markdown-it-toc-done-right'),truncatedSlugifyOption)
         .use(require('markdown-it-imsize'))
         .use(require('markdown-it-checkbox'))
         .use(require('markdown-it-mark'))

--- a/nodes/lib/serveMarkdown.js
+++ b/nodes/lib/serveMarkdown.js
@@ -23,15 +23,6 @@ const tilib = require('./tilib.js')
 const handlebars = require('handlebars')
 const yaml = require('js-yaml')
 
-// The heading anchors are truncated up to the colon.
-// E.g. The following heading 
-//        `## RULE_001 : You cannot cheat`
-// Link to the above heading:
-//     [link to RULE_001](#rule_001)
-// see also https://www.npmjs.com/package/markdown-it-anchor#user-friendly-urls
-const string = require('string')
-const truncatedSlugify = s => (string(s).split(":")[Ø]).slugify().toString()
-
 //const sanitizeHtml = require('sanitize-html')
 
 module.exports = function serveMarkdown(RED, node){
@@ -87,6 +78,17 @@ module.exports = function serveMarkdown(RED, node){
         bracesAreOptional: true
     }
 
+    // The heading anchors are truncated up to the colon.
+    // E.g. The following heading 
+    //        `## RULE_001 : You cannot cheat`
+    // Link to the above heading:
+    //     [link to RULE_001](#rule_001)
+    // see also https://www.npmjs.com/package/markdown-it-anchor#user-friendly-urls
+    // const truncatedSlugify = s => ((string(s).splitLeft(':',1))[Ø]).slugify().toString()
+    const anchorOptions = {
+         slugify : (s) => encodeURIComponent(String(s).split(':')[0].trim().toLowerCase().replace(/\s+/g, '-'))
+    }
+
     const md = require('markdown-it')({
         html: true, 
         linkify: true,
@@ -102,7 +104,7 @@ module.exports = function serveMarkdown(RED, node){
         .use(require('markdown-it-emoji'))
         .use(require('@gerhobbelt/markdown-it-include'),includeOptions)
         .use(require('markdown-it-playground'))
-        .use(require('markdown-it-anchor', { slugify: truncatedSlugify }))
+        .use(require('markdown-it-anchor'),anchorOptions)
         .use(require('markdown-it-table-of-contents'))
         .use(require('markdown-it-imsize'))
         .use(require('markdown-it-checkbox'))

--- a/nodes/lib/serveMarkdown.js
+++ b/nodes/lib/serveMarkdown.js
@@ -22,6 +22,16 @@ const express = require('express')
 const tilib = require('./tilib.js')
 const handlebars = require('handlebars')
 const yaml = require('js-yaml')
+
+// The heading anchors are truncated up to the colon.
+// E.g. The following heading 
+//        `## RULE_001 : You cannot cheat`
+// Link to the above heading:
+//     [link to RULE_001](#rule_001)
+// see also https://www.npmjs.com/package/markdown-it-anchor#user-friendly-urls
+const string = require('string')
+const truncatedSlugify = s => (string(s).split(":")[Ø]).slugify().toString()
+
 //const sanitizeHtml = require('sanitize-html')
 
 module.exports = function serveMarkdown(RED, node){
@@ -92,7 +102,7 @@ module.exports = function serveMarkdown(RED, node){
         .use(require('markdown-it-emoji'))
         .use(require('@gerhobbelt/markdown-it-include'),includeOptions)
         .use(require('markdown-it-playground'))
-        .use(require('markdown-it-anchor'))
+        .use(require('markdown-it-anchor', { slugify: truncatedSlugify }))
         .use(require('markdown-it-table-of-contents'))
         .use(require('markdown-it-imsize'))
         .use(require('markdown-it-checkbox'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-static-markdown",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Serve up a folder of static markdown files from Node-RED",
   "scripts": {
     "push": "git push origin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-static-markdown",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Serve up a folder of static markdown files from Node-RED",
   "scripts": {
     "push": "git push origin",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gitpushtags": "git push origin --tags"
   },
   "dependencies": {
-    "@gerhobbelt/markdown-it-footnote": "^3.0.2-4",
+    "@gerhobbelt/markdown-it-footnote": "3.0.2-4",
     "@gerhobbelt/markdown-it-include": "^1.1.3-7",
     "express": "^4.17.1",
     "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "handlebars": "^4.7.6",
     "js-yaml": "^3.14.0",
     "markdown-it": "^11.0.0",
-    "markdown-it-anchor": "^5.3.0",
+    "markdown-it-anchor": "^6.0.1",
     "markdown-it-attrs": "^3.0.3",
     "markdown-it-checkbox": "^1.1.0",
     "markdown-it-emoji": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "markdown-it-prism": "^2.1.1",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
-    "markdown-it-table-of-contents": "^0.4.4",
+    "markdown-it-toc-done-right": "^4.2.0",
     "markdown-it-textual-uml": "^0.1.3",
     "sanitize-html": "^1.27.4"
   },


### PR DESCRIPTION
Hi Julian,

I am planning to create many local links in my markup document to different sections (headers)
Currently this is a bit cumbersome as the links are based on the full header title which is converted to proper URL format.
I am looking for a shorter links.

I came up with a solution where the link is only based on the header title up to the first colon (`:`).
In case the header doesn't contain a colon then the full header title is used as before.

So if you have a header like:
```
### RULE01 : maximum speed in city is 50 km/h.
```
then you can easily create a link to it as follows
```
This is a [link to RULE01](#rule01)
```

So for this I had to set the slugify option for the anchor and toc extension.

I understand that you can argue that it is better to make this configurable so that user can choose if they want this truncation or not.  But I think it will take a lot of work to make this configurable and for this specific change it won't bring much value to disable the truncation.

Note that I also changed the toc extension and used same slugify option so that table of content generation still works.
Note also that toc generation still works if there are multiple headings with same title or same text up to the first colon.

If you have any comments, I am happy to hear them.
Jan.
